### PR TITLE
Research export: pinned public market data

### DIFF
--- a/research/market_export_run_request.md
+++ b/research/market_export_run_request.md
@@ -1,0 +1,7 @@
+# Mandatory baseline market-data export
+
+This branch exists only to trigger the public-data export workflow for Fantasy GM Step 3.
+
+- No private league or account data
+- StatHead source pinned to `3429ab7adf5d8e90e7be54394d008d91ff8bd15d`
+- DynastyProcess source pinned to `9aa625f9a44e56ec7dc91c4d355d24c37a235fe1`


### PR DESCRIPTION
Temporary, isolated PR used only to run the public market-data export workflow for Fantasy GM Step 3. It contains no private league data and should not be merged.