### PR TITLE
Research export: freeze Step 6 2026 public sources

### DIFF
--- a/research/STEP6_SOURCE_EXPORT_RUN.md
+++ b/research/STEP6_SOURCE_EXPORT_RUN.md
@@ -1,3 +1,5 @@
 # Step 6 source export run
 
 This temporary branch exists only to trigger the immutable 2026 public-source export workflow. Do not merge it.
+
+Rerun reason: inventory optional projection aliases before applying the independent-source gate.

--- a/research/STEP6_SOURCE_EXPORT_RUN.md
+++ b/research/STEP6_SOURCE_EXPORT_RUN.md
@@ -2,4 +2,4 @@
 
 This temporary branch exists only to trigger the immutable 2026 public-source export workflows. Do not merge it.
 
-Rerun reason: freeze the current FantasyPros half-PPR projection/VBD table and Yahoo-specific ADP table.
+Rerun reason: preserve the current FantasyPros VBD table and dynamic Yahoo ADP page even when the player table is client rendered.

--- a/research/STEP6_SOURCE_EXPORT_RUN.md
+++ b/research/STEP6_SOURCE_EXPORT_RUN.md
@@ -1,0 +1,3 @@
+# Step 6 source export run
+
+This temporary branch exists only to trigger the immutable 2026 public-source export workflow. Do not merge it.

--- a/research/STEP6_SOURCE_EXPORT_RUN.md
+++ b/research/STEP6_SOURCE_EXPORT_RUN.md
@@ -2,4 +2,4 @@
 
 This temporary branch exists only to trigger the immutable 2026 public-source export workflow. Do not merge it.
 
-Rerun reason: freeze the source inventory after treating changing ADP aliases as optional.
+Rerun reason: freeze the source inventory after treating current ADP aliases as optional inventory paths.

--- a/research/STEP6_SOURCE_EXPORT_RUN.md
+++ b/research/STEP6_SOURCE_EXPORT_RUN.md
@@ -1,5 +1,5 @@
 # Step 6 source export run
 
-This temporary branch exists only to trigger the immutable 2026 public-source export workflow. Do not merge it.
+This temporary branch exists only to trigger the immutable 2026 public-source export workflows. Do not merge it.
 
-Rerun reason: freeze the source inventory after treating current ADP aliases as optional inventory paths.
+Rerun reason: freeze the current FantasyPros half-PPR projection/VBD table and Yahoo-specific ADP table.

--- a/research/STEP6_SOURCE_EXPORT_RUN.md
+++ b/research/STEP6_SOURCE_EXPORT_RUN.md
@@ -2,4 +2,4 @@
 
 This temporary branch exists only to trigger the immutable 2026 public-source export workflows. Do not merge it.
 
-Rerun reason: preserve the current FantasyPros VBD table and dynamic Yahoo ADP page even when the player table is client rendered.
+Rerun reason: use the resilient FantasyPros freezer that retains the dynamic Yahoo ADP HTML as an audited source even when the table is client rendered.

--- a/research/STEP6_SOURCE_EXPORT_RUN.md
+++ b/research/STEP6_SOURCE_EXPORT_RUN.md
@@ -2,4 +2,4 @@
 
 This temporary branch exists only to trigger the immutable 2026 public-source export workflow. Do not merge it.
 
-Rerun reason: inventory optional projection aliases before applying the independent-source gate.
+Rerun reason: freeze the source inventory after treating changing ADP aliases as optional.


### PR DESCRIPTION
Temporary isolated PR used only to run the Step 6 source-freezing workflow. It contains no private league data and should not be merged.